### PR TITLE
Update role for modern Ansible

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,17 +1,7 @@
 ---
-
 - name: Restart systemd-networkd
-  service:
+  ansible.builtin.service:
     name: "systemd-networkd"
     state: "restarted"
-
-- name: Restart wg-quick profiles
-  service:
-    name: "{{ wireguard_wg_quick_service_prefix }}{{ item.key }}"
-    state: "restarted"
-  with_dict: wireguard_profiles
-  when: |
-    "dump_conf_{{ item.key }} is defined and dump_conf_{{ item.key }}.changed"
-    "and item.key.enable"
 
 # vim: set ts=2 sw=2:

--- a/tasks/dist_vars.yml
+++ b/tasks/dist_vars.yml
@@ -1,7 +1,6 @@
 ---
-
 - name: Include distribution specific variables
-  include_vars:
+  ansible.builtin.include_vars:
     file: "{{ item }}"
     name: _os_specific
   with_first_found:
@@ -11,10 +10,8 @@
     - "default.yml"
 
 - name: Set OS specific vars if undefined
-  set_fact: {
-    "{{ item.key }}":
-      "{{ hostvars[inventory_hostname][item.key] | default(item.value) }}"
-  }
+  ansible.builtin.set_fact:
+    "{{ item.key }}": "{{ hostvars[inventory_hostname][item.key] | default(item.value) }}"
   with_dict: "{{ _os_specific }}"
 
 # vim: set ts=2 sw=2:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,7 +1,8 @@
 ---
-
 - name: Installing Wireguard
-  package: "name={{ item }} state=present"
-  with_items: "{{ wireguard_packages }}"
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: "present"
+  loop: "{{ wireguard_packages }}"
 
 # vim: set ts=2 sw=2:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,45 +1,52 @@
 ---
+- name: Import distribution-specific variables
+  ansible.builtin.import_tasks: dist_vars.yml
 
-- import_tasks: dist_vars.yml
-
-- import_tasks: install.yml
+- name: Import installation tasks
+  ansible.builtin.import_tasks: install.yml
 
 - name: Set boolean method check to all profiles
-  set_fact:
-    wireguard_profiles_bool_methods: "{{
-      wireguard_profiles_bool_methods|default({})|combine({
-        item.key: {
-          'use_wg_quick': item.value.method == 'wg-quick',
-          'use_systemd_networkd': item.value.method == 'systemd-networkd',
-          'use_wg_conf_dump': item.value.method == 'wireguard-conf'
-        }
-      })
-    }}"
+  ansible.builtin.set_fact:
+    wireguard_profiles_bool_methods:
+      "{{
+        wireguard_profiles_bool_methods | default({}) | combine({
+          item.key: {
+            'use_wg_quick': item.value.method == 'wg-quick',
+            'use_systemd_networkd': item.value.method == 'systemd-networkd',
+            'use_wg_conf_dump': item.value.method == 'wireguard-conf'
+          }
+        })
+      }}"
   with_dict: "{{ wireguard_profiles }}"
+  tags:
+    - skip_ansible_lint # Required as it doesn't interpret properly the multi-line Jinja template
 
-- name: Update profiles with boolean methods
-  set_fact:
-    wireguard_profiles: "{{ wireguard_profiles|combine(wireguard_profiles_bool_methods, recursive=True) }}"
+- name: Set profiles with boolean methods
+  ansible.builtin.set_fact:
+    wireguard_profiles_bool: "{{ wireguard_profiles | combine(wireguard_profiles_bool_methods, recursive=True) }}"
 
-- include_tasks: wg_quick.yml
+- name: Include 'wg_quick' tasks
+  ansible.builtin.include_tasks: wg_quick.yml
   vars:
     profile: "{{ item.value }}"
     profile_name: "{{ item.key }}"
-  with_dict: "{{ wireguard_profiles }}"
+  with_dict: "{{ wireguard_profiles_bool }}"
   when: item.value.use_wg_quick
 
-- include_tasks: systemd_networkd.yml
+- name: Include 'systemd_networkd' tasks
+  ansible.builtin.include_tasks: systemd_networkd.yml
   vars:
     profile: "{{ item.value }}"
     profile_name: "{{ item.key }}"
-  with_dict: "{{ wireguard_profiles }}"
+  with_dict: "{{ wireguard_profiles_bool }}"
   when: item.value.use_systemd_networkd
 
-- include_tasks: wg_conf.yml
+- name: Include 'wg_conf' tasks
+  ansible.builtin.include_tasks: wg_conf.yml
   vars:
     profile: "{{ item.value }}"
     profile_name: "{{ item.key }}"
-  with_dict: "{{ wireguard_profiles }}"
+  with_dict: "{{ wireguard_profiles_bool }}"
   when: item.value.use_wg_conf_dump
 
 # vim: set ts=2 sw=2:

--- a/tasks/systemd_networkd.yml
+++ b/tasks/systemd_networkd.yml
@@ -1,10 +1,18 @@
 ---
-
 - name: Install link definition
-  template:
+  ansible.builtin.template:
     src: "systemd_networkd.netdev.j2"
     dest: "/etc/systemd/network/{{ profile_name }}.netdev"
-    mode: 0660
+    mode: "0660"
+    owner: "systemd-network"
+    group: "root"
+  notify: Restart systemd-networkd
+
+- name: Install network definition
+  ansible.builtin.template:
+    src: "systemd_networkd.network.j2"
+    dest: "/etc/systemd/network/{{ profile_name }}.network"
+    mode: "0660"
     owner: "systemd-network"
     group: "root"
   notify: Restart systemd-networkd

--- a/tasks/systemd_networkd.yml
+++ b/tasks/systemd_networkd.yml
@@ -16,5 +16,6 @@
     owner: "systemd-network"
     group: "root"
   notify: Restart systemd-networkd
+  when: "'addresses' in profile and profile.addresses"
 
 # vim: set ts=2 sw=2:

--- a/tasks/wg_conf.yml
+++ b/tasks/wg_conf.yml
@@ -1,9 +1,8 @@
 ---
-
 - name: Install profile
-  template:
+  ansible.builtin.template:
     src: "wireguard.conf.j2"
     dest: "{{ wireguard_conf_path }}/{{ profile_name }}"
-    mode: 0640
+    mode: "0640"
 
 # vim: set ts=2 sw=2:

--- a/tasks/wg_quick.yml
+++ b/tasks/wg_quick.yml
@@ -1,30 +1,38 @@
 ---
-
 - name: Install profile
-  template:
+  ansible.builtin.template:
     src: "wireguard.conf.j2"
     dest: "{{ wireguard_conf_path }}/{{ profile_name }}.conf"
-    mode: 0640
-  register: "dump_conf_{{ profile_name }}"
+    mode: "0640"
+  register: install_profile
 
 - name: Install wg_quick service for openrc
-  template:
+  ansible.builtin.template:
     src: "wg_quick.openrc.j2"
     dest: "/etc/init.d/wg-quick"
-    mode: 0755
+    mode: "0755"
   when: ansible_service_mgr == "openrc"
 
 - name: Create a service specific to this profile for openrc
-  file:
+  ansible.builtin.file:
     src: "/etc/init.d/wg-quick"
     dest: "/etc/init.d/wg-quick.{{ profile_name }}"
     state: "link"
   when: ansible_service_mgr == "openrc"
 
 - name: Enable profile
-  service:
+  ansible.builtin.service:
     name: "{{ wireguard_wg_quick_service_prefix }}{{ profile_name }}"
     enabled: true
   when: profile.enable is defined and profile.enable
+
+- name: "Restart wg-quick@{{ profile_name }}"
+  ansible.builtin.service:
+    name: "wg-quick@{{ profile_name }}"
+    state: "restarted"
+  when:
+    - profile.enable is defined
+    - profile.enable
+    - install_profile.changed
 
 # vim: set ts=2 sw=2:

--- a/templates/systemd_networkd.netdev.j2
+++ b/templates/systemd_networkd.netdev.j2
@@ -1,3 +1,4 @@
+#jinja2: lstrip_blocks: True
 [NetDev]
 Name={{ profile_name }}
 Kind=wireguard
@@ -10,33 +11,34 @@ Description=Wireguard {{ profile_name }}
 {% endif %}
 
 [WireGuard]
-{% if profile.listen_port|default() %}
+{% if profile.listen_port|default() -%}
     ListenPort = {{ profile.listen_port }}
 {% endif %}
 PrivateKey = {{ profile.private_key }}
-{% if profile.fwmark|default() %}
+{% if profile.fwmark|default() -%}
     FwMark = {{ profile.fwmark }}
 {% endif %}
 
-{% for peer in profile.peers %}
+{% for peer in profile.peers -%}
     [WireGuardPeer]
-    {% if peer.comment|default() %}
-# {{ peer.comment }}
-    {% endif %}
+    {% if peer.comment|default() -%}
+        # {{ peer.comment }}
+    {% endif -%}
     PublicKey = {{ peer.public_key }}
-    {% if peer.preshared_key|default() %}
+    {% if peer.preshared_key|default() -%}
         PresharedKey = {{ peer.preshared_key }}
-    {% endif %}
-    {% for i in peer.allowed_ips %}
-        AllowedIPs = {{ i }}
-    {% endfor %}
-    {% if peer.endpoint|default() %}
-        Endpoint = {{ peer.endpoint }}
-    {% endif %}
-    {% if peer.persistent_keepalive|default() %}
-        PersistentKeepalive = {{ peer.persistent_keepalive }}
-    {% endif %}
+    {% endif -%}
 
-{% endfor %}
+    {% for i in peer.allowed_ips -%}
+        AllowedIPs = {{ i }}
+    {% endfor -%}
+
+    {% if peer.endpoint|default() -%}
+        Endpoint = {{ peer.endpoint }}
+    {% endif -%}
+    {% if peer.persistent_keepalive|default() -%}
+        PersistentKeepalive = {{ peer.persistent_keepalive }}
+    {% endif -%}
+{% endfor -%}
 
 {% if profile.additional_opts|default() %}{{ profile.additional_opts }}{% endif %}

--- a/templates/systemd_networkd.network.j2
+++ b/templates/systemd_networkd.network.j2
@@ -1,0 +1,11 @@
+#jinja2: lstrip_blocks: True
+[Match]
+Name={{ profile_name }}
+
+[Network]
+{% for address in profile.addresses -%}
+    Address={{ address }}
+{% endfor -%}
+{% for dns in profile.dns | default([]) -%}
+    DNS={{ dns }}
+{% endfor -%}

--- a/templates/wireguard.conf.j2
+++ b/templates/wireguard.conf.j2
@@ -1,51 +1,51 @@
+#jinja2: lstrip_blocks: True
 #{{ ansible_managed }}
 
 [Interface]
-{% if profile.use_wg_quick %}
-    {% if profile.addresses|default([]) %}
+{% if profile.use_wg_quick -%}
+    {% if profile.addresses|default([]) -%}
         Address = {{ profile.addresses|join(", ") }}
     {% endif %}
-    {% if profile.dns|default([]) %}
+    {% if profile.dns|default([]) -%}
         DNS = {{ profile.dns|join(", ") }}
     {% endif %}
-    {% if profile.mtu|default([]) %}
+    {% if profile.mtu|default([]) -%}
         MTU = {{ profile.mtu }}
     {% endif %}
-    {% if profile.table|default([]) %}
+    {% if profile.table|default([]) -%}
         Table = {{ profile.table }}
     {% endif %}
-    {% if profile.postup|default() %}
+    {% if profile.postup|default() -%}
         PostUp = {{ profile.postup }}
     {% endif %}
-    {% if profile.postdown|default() %}
+    {% if profile.postdown|default() -%}
         PostDown = {{ profile.postdown }}
     {% endif %}
 {% endif %}
-{% if profile.listen_port|default() %}
+{% if profile.listen_port|default() -%}
     ListenPort = {{ profile.listen_port }}
 {% endif %}
 PrivateKey = {{ profile.private_key }}
-{% if profile.fwmark|default() %}
+{% if profile.fwmark|default() -%}
     FwMark = {{ profile.fwmark }}
 {% endif %}
 
-{% for peer in profile.peers %}
+{% for peer in profile.peers -%}
     [Peer]
-    {% if peer.comment|default() %}
+    {% if peer.comment|default() -%}
         # {{ peer.comment }}
-    {% endif %}
+    {% endif -%}
     PublicKey = {{ peer.public_key }}
-    {% if peer.preshared_key|default() %}
+    {% if peer.preshared_key|default() -%}
         PresharedKey = {{ peer.preshared_key }}
-    {% endif %}
+    {% endif -%}
     AllowedIPs = {{ peer.allowed_ips|join(", ") }}
-    {% if peer.endpoint|default() %}
+    {% if peer.endpoint|default() -%}
         Endpoint = {{ peer.endpoint }}
     {% endif %}
-    {% if peer.persistent_keepalive|default() %}
+    {% if peer.persistent_keepalive|default() -%}
         PersistentKeepalive = {{ peer.persistent_keepalive }}
     {% endif %}
-
 {% endfor %}
 
 {% if profile.additional_opts|default() %}{{ profile.additional_opts }}{% endif %}

--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -1,5 +1,4 @@
 ---
-
 wireguard_packages:
   - wireguard-tools
 

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,5 +1,4 @@
 ---
-
 wireguard_packages:
   - wireguard-tools
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,4 @@
 ---
-
 wireguard_packages:
   - wireguard
 

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,4 @@
 ---
-
 wireguard_packages:
   - wireguard-tools
   - wireguard-dkms

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,5 +1,4 @@
 ---
-
 wireguard_packages:
   - wireguard-tools
   - wireguard-dkms


### PR DESCRIPTION
Hello,

I've recently had to use this role to deploy some Wireguard configurations, and I adapted it in some ways.
Some construct in the current version aren't valid anymore with newer version of Ansible.

I also tried to follow `ansible-lint`, and have a managed network interface with `systemd-networkd` if we use it.